### PR TITLE
Intercept redirect on metrics application's endpoint and give a clear error message

### DIFF
--- a/clients/backend_test.go
+++ b/clients/backend_test.go
@@ -28,10 +28,11 @@ var _ = Describe("Backend", func() {
 				MaxIdleConnsPerHost: 100,
 			})
 
-			client := factory.NewClient(&models.Route{ServerCertDomainSan: "my.san"})
+			client := factory.NewClient(&models.Route{ServerCertDomainSan: "my.san"}, false)
 
 			Expect(client).ToNot(BeNil())
 			Expect(client.Timeout).To(Equal(30 * time.Second))
+			Expect(client.CheckRedirect).ToNot(BeNil())
 
 			httpTrans, ok := client.Transport.(*http.Transport)
 			Expect(ok).To(BeTrue())

--- a/scrapers/scrape.go
+++ b/scrapers/scrape.go
@@ -83,7 +83,7 @@ func (s Scraper) Scrape(route *models.Route, metricPathDefault string, headers h
 		}
 		req.URL.RawQuery = urlParamsCurrent.Encode()
 	}
-	client := s.backendFactory.NewClient(route)
+	client := s.backendFactory.NewClient(route, false)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If an application respond with a redirect on the metrics endpoint, promfetcher could follow the redirection with external url instead of instance url (and could generate an error difficult to understand)!

For clarity, this PR intercept the redirect and return an error (via `promfetcher_scrape_error` metric)