### PR TITLE
change the Accept header sent to the exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,105 +1,129 @@
 # Promfetcher
 
-Promfetcher was made for [cloud foundry](https://cloudfoundry.org) and the idea behind is to give ability to fetch metrics from all app instances in a cloud foundry environment.
+Promfetcher was made for [Cloud Foundry] in order to expose [OpenMetrics] from all instances
+of an App in a Cloud Foundry environment.
 
-User can retrieve is metrics by simply call `/v1/apps/[org_name]/[space_name]/[app_name]/metrics` or by route url `/v1/apps/metrics?route_url=my.route.com` which will merge all metrics from app(s) instances and add labels:
+User can retrieve the metrics by simply calling `/v1/apps/${org_name}/${space_name}/${app_name}/metrics`,
+or by the application route URL through `/v1/apps/metrics?route_url=my.route.com`,
+which will merge all the metrics from an App instances,
+then add the following labels (similar to what can be found in the variable [`VCAP_APPLICATION`]):
 
-- `organization_id`
-- `space_id`
-- `app_id`
-- `organization_name`
-- `space_name`
-- `app_name`
-- `index` - app instance index
-- `instance_id` - the same as index
-- `instance` - real container address
+- `organization_id` - The GUID identifying the org where the app is deployed.
+- `organization_name` - The human-readable name of the org where the app is deployed.
+- `space_id` - The GUID identifying the space where the app is deployed.
+- `space_name` - The human-readable name of the space where the app is deployed.
+- `app_id` - The GUID identifying the app.
+- `app_name` - The name assigned to the app when it was pushed.
+- `index` - The index number of the app instance.
+- `instance_id` - (same as the `index`)
+- `instance` - The real IP address and port of the container running the App instance.
 
-It also a service broker for cloud foundry to be able to set metrics endpoint for a particular which not use `/metrics` by default.
+It is also a Cloud Foundry [service broker] able to expose an endpoint containing some system metrics
+for applications without one.
 
-## Example
+[Cloud Foundry]: https://cloudfoundry.org
+[service broker]: https://docs.cloudfoundry.org/services/overview.html
+[`VCAP_APPLICATION`]: https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-APPLICATION
 
-Metrics from app instance 0:
+## Usage
+
+### Set up
+
+On Cloud Foundry, you should deploy it through its corresponding [BOSH release]:
+https://github.com/orange-cloudfoundry/promfetcher-release
+
+[BOSH release]: https://bosh.io/releases/
+
+### Standard endpoint
+
+If your Apps metrics are available on the `/metrics` path (as per [OpenMetrics] recommendations),
+you have nothing else to do and you can retrieve App instances metrics by simply calling one of:
+
+- `promfetcher.example.net/v1/apps/{org_name}/{space_name}/{app_name}/metrics`
+- `promfetcher.example.net/v1/apps/{app_id}/metrics`
+- `promfetcher.example.net/v1/apps/metrics?app="[org_name]/[space_name]/[app_name]"`
+- `promfetcher.example.net/v1/apps/metrics?app="[app_id]"`
+- `promfetcher.example.net/v1/apps/{route.url.com}/metrics`
+- `promfetcher.example.net/v1/apps/metrics?route_url="[route.url.com]"`
+
+To retrieve only the metrics exposed from your application (without the Promfetcher sugar coating),
+use `/only-app-metrics` instead of `/metrics`, i.e.:
+
+- `promfetcher.example.net/v1/apps/{org_name}/{space_name}/{app_name}/only-app-metrics`
+- `promfetcher.example.net/v1/apps/only-app-metrics?app="[app_id]"`
+
+### Setting a custom endpoint
+
+Add to your querystring the parameter `metric_path={/my-metrics/endpoint}`, i.e.:
+
+- `promfetcher.example.net/v1/apps/{org_name}/{space_name}/{app_name}/metrics?metric_path=/my-metrics/endpoint`
+
+### Pass HTTP headers to the App
+
+If you do a request with headers, they are all passed to the App.
+
+This is useful for authentication purpose, for example:
+
+1. I have an App with metrics on `/metrics` which is protected with HTTP Basic Auth
+2. You can perform curl: `curl https://username:password@promfetcher.example.net/v1/apps/my-app/metrics`
+3. HTTP Basic Auth headers are passed to the App, and you can retrieve the information
+   (note that Promfetcher does not store any data)
+
+## Under the hood
+
+### How does it work?
+
+Promfetcher only needs [gorouter] and will read route table from it.
+
+When asking metrics for an App, Promfetcher will asynchronously call all App instances
+(provided by the gorouter routing table) metrics endpoint and merge them together with new labels.
+
+[gorouter]: https://github.com/cloudfoundry/gorouter
+
+Example, given an App with metrics from instance 0:
 
 ```
 go_memstats_mspan_sys_bytes{} 65536
 ```
 
-Metrics from app instance 1:
+And metrics from App instance 1:
 
 ```
 go_memstats_mspan_sys_bytes{} 5600
 ```
 
-become:
+Promfetcher will merge them to:
 
 ```
 go_memstats_mspan_sys_bytes{organization_id="7d66c7e7-196a-40e5-a259-f5afaf6a56f4",space_id="2ac205af-e18f-49a9-9a8b-48ef2bab2292",app_id="621617db-9dd9-4211-8848-b245f3ea16b2",organization_name="system",space_name="tools",app_name="app",index="0",instance_id="0",instance="172.76.112.90:61038"} 65536
 go_memstats_mspan_sys_bytes{organization_id="7d66c7e7-196a-40e5-a259-f5afaf6a56f4",space_id="2ac205af-e18f-49a9-9a8b-48ef2bab2292",app_id="621617db-9dd9-4211-8848-b245f3ea16b2",organization_name="system",space_name="tools",app_name="app",index="1",instance_id="1",instance="172.76.112.91:61010"} 65536
 ```
 
-## How to use ?
 
-## If metrics available on `/metrics` on your app
+### Graceful shutdown
 
-You have nothing to do, you can retrieve app instances metrics by simply call one of:
+Upon receiving `SIGINT`, `SIGTERM` or `SIGUSR1`, Promfetcher will stop listening to new connections
+and will wait up to 15 seconds to let the processing transactions a chance to finish before exiting.
 
-- [my.promfetcher.com/v1/apps/\[org_name\]/\[space_name\]/\[app_name\]/metrics](my.promfetcher.com/v1/apps/{org_name}/{space_name}/{app_name}/metrics)
-- [my.promfetcher.com/v1/apps/\[app_id\]/metrics](my.promfetcher.com/v1/apps/{app_id}/metrics)
-- [my.promfetcher.com/v1/apps/metrics?app="\[org_name\]/\[space_name\]/\[app_name\]"](my.promfetcher.com/v1/apps/metrics?app="\[org_name\]/\[space_name\]/\[app_name\]")
-- [my.promfetcher.com/v1/apps/metrics?app="\[app_id\]"](my.promfetcher.com/v1/apps/metrics?app="\[app_id\]")
-- [my.promfetcher.com/v1/apps/\[route.url.com\]/metrics](my.promfetcher.com/v1/apps/{route.url.com}/metrics)
-- [my.promfetcher.com/v1/apps/metrics?route_url="\[route.url.com\]"](my.promfetcher.com/v1/apps/metrics?route_url="\[route.url.com\]")
+### Health Check
 
-## Set a different endpoint
+The default Promfetcher [Health Check] is of "port" type on `8080`.
 
-Add url param `metric_path=/my-metrics/endpoint`, e.g.:
+Promfetcher answers with an HTTP 200 status if healthy and HTTP 503 otherwise.
 
-- [my.promfetcher.com/v1/apps/\[org_name\]/\[space_name\]/\[app_name\]/metrics?metric_path=/my-metrics/endpoint](my.promfetcher.com/v1/apps/{org_name}/{space_name}/{app_name}/metrics?metric_path=/my-metrics/endpoint)
+[Health Check]: https://docs.cloudfoundry.org/devguide/deploy-apps/healthchecks.html
 
-## Pass http headers to app, useful for authentication
+The administrator can send a `SIGUSR1` to force an unhealthy status in addition to stop it gracefully.
 
-If you do a request with headers, they are all passed to app.
+### Promfetcher's internal metrics
 
-This is useful for authentication purpose, example on basic auth
+Promfetcher metrics are exposed on the [OpenMetrics] standard path `/metrics` and contains the following:
 
-1. I have an app with metrics on `/metrics` but it is protected with basic auth `foo`/`bar`
-2. You can perform curl: `curl https://foo:bar@my.promfetcher.com/v1/apps/my-app/metrics`
-3. Basic auth header are passed to app and you can retrieve information (note that promfetcher do not store anything)
+[//]: # (curl -s https://promfetcher.example.net/metrics | sed -n 's/^# HELP \&#40;promfetch_[^ ]*\&#41;/- `\1`:/p')
 
-## Retrieving only metrics from your app and not those from external
+- `promfetch_metric_fetch_failed_total`: Number of non-fetched metrics without be a normal error.
+- `promfetch_metric_fetch_success_total`: Number of fetched metrics succeeded for an App (App instances calls are summed).
+- `promfetch_latest_time_scrape_route`: Last time that route has been scraped, in seconds.
+- `promfetch_scrape_route_failed_total`: Number of non-fetched metrics without be an normal error.
 
-Use `/only-app-metrics` instead of `/metrics`, e.g.:
-
-- [my.promfetcher.com/v1/apps/\[org_name\]/\[space_name\]/\[app_name\]/only-app-metrics](my.promfetcher.com/v1/apps/{org_name}/{space_name}/{app_name}/only-app-metrics)
-- [my.promfetcher.com/v1/apps/only-app-metrics?app="\[app_id\]"](my.promfetcher.com/v1/apps/only-app-metrics?app="\[app_id\]")
-
-## How it works ?
-
-Promfetcher only needs [gorouter](https://github.com/cloudfoundry/gorouter) and will read route table from it.
-
-When asking metrics for an app, promfetcher will call async all app instance (gave by routing table from gorouter) metrics endpoint and merge them together with new labels.
-
-## How to deploy ?
-
-You should deploy it with boshrelease associated with: https://github.com/orange-cloudfoundry/promfetcher-release
-
-## Metrics
-
-Promfetcher expose metrics on `/metrics`:
-
-- `promfetch_metric_fetch_failed_total`: Number of non fetched metrics without be an normal error.
-- `promfetch_metric_fetch_success_total`: Number of fetched metrics succeeded for an app (app instance call are summed).
-- `promfetch_latest_time_scrape_route`: Last time that route has been scraped in seconds.
-- `promfetch_scrape_route_failed_total`: Number of non fetched metrics without be an normal error.
-
-## Graceful shutdown
-
-Promfetcher when receiving a SIGINT or SIGTERM or SIGUSR1 signal will stop listening new connections and will wait to finish opened requests before stopping. If opened requests are not finished after 15 seconds the server will be hard closed.
-
-User can
-
-## Health Check
-
-Health check is available by default on port 8080. If promfetcher is not healthy or not yet healthy it will respond a 503 error, if not it will respond a 200.
-
-User can send a `USR1` signal on promfetcher to set unhealthy on health check in addition to stop gracefully.
+[OpenMetrics]: https://github.com/OpenObservability/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md

--- a/api/init.go
+++ b/api/init.go
@@ -22,20 +22,37 @@ func Register(rtr *mux.Router, metFetcher *fetchers.MetricsFetcher, broker *Brok
 	}
 
 	handlerMetrics := handlers.CompressHandler(http.HandlerFunc(api.metrics))
-	rtr.Handle("/v1/apps/{appIdOrPathOrName:.*}/metrics", handlerMetrics).
-		Methods(http.MethodGet)
-
-	rtr.Handle("/v1/apps/metrics", handlerMetrics).
-		Methods(http.MethodGet)
-
 	handlerOnlyAppMetrics := handlers.CompressHandler(forceOnlyForApp(http.HandlerFunc(api.metrics)))
 
-	rtr.Handle("/v1/apps/{appIdOrPathOrName:.*}/only-app-metrics", handlerOnlyAppMetrics).
+	// API v1: deprecated
+	routerApiV1 := rtr.PathPrefix("/v1").Subrouter()
+	routerApiV1.Handle("/apps/{appIdOrPathOrName:.*}/metrics", handlerMetrics).
 		Methods(http.MethodGet)
 
-	rtr.Handle("/v1/apps/only-app-metrics", handlerOnlyAppMetrics).
+	routerApiV1.Handle("/apps/metrics", handlerMetrics).
 		Methods(http.MethodGet)
 
+	routerApiV1.Handle("/apps/{appIdOrPathOrName:.*}/only-app-metrics", handlerOnlyAppMetrics).
+		Methods(http.MethodGet)
+
+	routerApiV1.Handle("/apps/only-app-metrics", handlerOnlyAppMetrics).
+		Methods(http.MethodGet)
+
+	// API v2
+	routerApiV2 := rtr.PathPrefix("/v2").Subrouter()
+	routerApiV2.Handle("/apps/{appIdOrPathOrName:.*}/metrics", handlerMetrics).
+		Methods(http.MethodGet)
+
+	routerApiV2.Handle("/apps/metrics", handlerMetrics).
+		Methods(http.MethodGet)
+
+	routerApiV2.Handle("/apps/{appIdOrPathOrName:.*}/only-app-metrics", handlerOnlyAppMetrics).
+		Methods(http.MethodGet)
+
+	routerApiV2.Handle("/apps/only-app-metrics", handlerOnlyAppMetrics).
+		Methods(http.MethodGet)
+
+	// non-API routes
 	rtr.NewRoute().MatcherFunc(func(req *http.Request, m *mux.RouteMatch) bool {
 		return strings.HasPrefix(req.URL.Path, "/broker/v2")
 	}).Handler(http.StripPrefix("/broker", broker.Handler()))

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -3,15 +3,27 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/orange-cloudfoundry/promfetcher/models"
 	"github.com/prometheus/common/expfmt"
 
 	"github.com/orange-cloudfoundry/promfetcher/errors"
 )
 
 func (a Api) metrics(w http.ResponseWriter, req *http.Request) {
+	// extract the API version from the requested path (ie: /v2)
+	// and set it to an HTTP header
+	apiVersion := regexp.MustCompile("/v([0-9]+)(?:/|$)").FindStringSubmatch(req.URL.Path)
+	if len(apiVersion) == 2 {
+		req.Header.Set(models.XPromfetcherApiVersion, apiVersion[1])
+	} else {
+		// default to v1
+		req.Header.Set(models.XPromfetcherApiVersion, "1")
+	}
+
 	appIdOrPathOrName, ok := mux.Vars(req)["appIdOrPathOrName"]
 	if !ok {
 		appIdOrPathOrName = req.URL.Query().Get("app")

--- a/models/api.go
+++ b/models/api.go
@@ -1,4 +1,0 @@
-package models
-
-//XPromfetcherApiVersion name of the HTTP header corresponding to the Promfetcher API version
-const XPromfetcherApiVersion = `X-Promfetcher-API-version`

--- a/models/api.go
+++ b/models/api.go
@@ -1,0 +1,4 @@
+package models
+
+//XPromfetcherApiVersion name of the HTTP header corresponding to the Promfetcher API version
+const XPromfetcherApiVersion = `X-Promfetcher-API-version`

--- a/scrapers/scrape.go
+++ b/scrapers/scrape.go
@@ -12,7 +12,6 @@ import (
 	"github.com/orange-cloudfoundry/promfetcher/clients"
 	"github.com/orange-cloudfoundry/promfetcher/errors"
 	"github.com/orange-cloudfoundry/promfetcher/models"
-	"github.com/prometheus/common/expfmt"
 )
 
 type Scraper struct {
@@ -67,14 +66,6 @@ func (s Scraper) Scrape(route *models.Route, metricPathDefault string, headers h
 		for k, v := range headers {
 			req.Header[k] = v
 		}
-	}
-	// Prometheus parser is not OpenMetrics compliant
-	// See: prometheus/common issues: 214, 829
-	req.Header.Set("Accept", string(expfmt.FmtText))
-	// keep the OpenMetrics accept HTTP header for the /v1 endpoint
-	if req.Header.Get(models.XPromfetcherApiVersion) == "1" {
-		req.Header.Set(models.XPromfetcherApiVersion, "1")
-		req.Header.Set("Accept", `application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`)
 	}
 	req.Header.Add("Accept-Encoding", "gzip")
 	req.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", fmt.Sprintf("%f", (30*time.Second).Seconds()))

--- a/scrapers/scrape.go
+++ b/scrapers/scrape.go
@@ -12,9 +12,8 @@ import (
 	"github.com/orange-cloudfoundry/promfetcher/clients"
 	"github.com/orange-cloudfoundry/promfetcher/errors"
 	"github.com/orange-cloudfoundry/promfetcher/models"
+	"github.com/prometheus/common/expfmt"
 )
-
-const acceptHeader = `application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`
 
 type Scraper struct {
 	backendFactory *clients.BackendFactory
@@ -69,7 +68,14 @@ func (s Scraper) Scrape(route *models.Route, metricPathDefault string, headers h
 			req.Header[k] = v
 		}
 	}
-	req.Header.Add("Accept", acceptHeader)
+	// Prometheus parser is not OpenMetrics compliant
+	// See: prometheus/common issues: 214, 829
+	req.Header.Set("Accept", string(expfmt.FmtText))
+	// keep the OpenMetrics accept HTTP header for the /v1 endpoint
+	if req.Header.Get(models.XPromfetcherApiVersion) == "1" {
+		req.Header.Set(models.XPromfetcherApiVersion, "1")
+		req.Header.Set("Accept", `application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`)
+	}
 	req.Header.Add("Accept-Encoding", "gzip")
 	req.Header.Set("X-Prometheus-Scrape-Timeout-Seconds", fmt.Sprintf("%f", (30*time.Second).Seconds()))
 	req.Header.Set("X-Forwarded-Proto", scheme)


### PR DESCRIPTION
change the Accept header sent to the exporters

Create a new version of the API endpoint (`/v2`) and deprecate `/v1`.
This new version change the `Accept` HTTP header sent to the exporters requested (from `application/openmetrics-text` … to `text/plain`) because the Go library we use does not seems to support all OpenMetrics specificities ^1.

The requests sent to the exporters contains a new HTTP header `X-Promfetcher-API-version` with the Promfetchers API version.

^1: Java actuator does respect the OpenMetrics specifications; the double quotes in the comments is not supported for example:
> `# HELP process_cpu_usage The \"recent cpu usage\" for the Java Virtual Machine process`

See also:
[1]: https://github.com/prometheus/client_golang/issues/829#issuecomment-752753238
[2]: https://github.com/prometheus/common/issues/214